### PR TITLE
Fix interpolated raw string literals breaking colorization

### DIFF
--- a/src/Viasfora.Languages/BraceScanners/CSharpBraceScanner.cs
+++ b/src/Viasfora.Languages/BraceScanners/CSharpBraceScanner.cs
@@ -73,7 +73,7 @@ namespace Winterdom.Viasfora.Languages.BraceScanners {
           this.multiLine = true;
           tc.Skip(2);
           this.ParseMultiLineString(tc);
-        } else if ( tc.Char() == '$' && tc.NChar() == '"' ) {
+        } else if ( tc.Char() == '$' && tc.NChar() == '"' && tc.NNChar() != '"') {
           // Roslyn interpolated string
           this.parsingExpression = false;
           this.status = stIString;

--- a/tests/Viasfora.Tests/BraceScanners/CSharpBraceScannerTests.cs
+++ b/tests/Viasfora.Tests/BraceScanners/CSharpBraceScannerTests.cs
@@ -218,6 +218,15 @@ callCommented2(4);
       var chars = ExtractWithLines(extractor, input.Trim(), 0, 0);
       Assert.Equal(0, chars.Count);
     }
+
+    [Fact]
+    public void RawString2() {
+      String input = "($\"\"\"some \r\n string with \r\n{\"quotes\"} \"\"\")";
+      var extractor = new CSharpBraceScanner();
+      var chars = ExtractWithLines(extractor, input.Trim(), 0, 0);
+      Assert.Equal(3, chars.Count); // should be 4 (with interpolation support) or 2 (without interpolation support)
+    }
+
     // TODO: Support later
     /*
     [Fact]

--- a/tests/Viasfora.Tests/BraceScanners/CSharpBraceScannerTests.cs
+++ b/tests/Viasfora.Tests/BraceScanners/CSharpBraceScannerTests.cs
@@ -224,7 +224,7 @@ callCommented2(4);
       String input = "($\"\"\"some \r\n string with \r\n{\"quotes\"} \"\"\")";
       var extractor = new CSharpBraceScanner();
       var chars = ExtractWithLines(extractor, input.Trim(), 0, 0);
-      Assert.Equal(3, chars.Count); // should be 4 (with interpolation support) or 2 (without interpolation support)
+      Assert.Equal(2, chars.Count); // should be 4 when interpolation is supported
     }
 
     // TODO: Support later


### PR DESCRIPTION
Fixes #347 

This does not support interpolation for raw string literals but it stops them from breaking the colorization.