### PR TITLE
Enable ARM64 support.

### DIFF
--- a/src/Viasfora.Core/Viasfora.Core.csproj
+++ b/src/Viasfora.Core/Viasfora.Core.csproj
@@ -200,7 +200,7 @@
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Sdk">
-      <Version>17.6.36389</Version>
+      <Version>17.10.40171</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Viasfora.Rainbow/Viasfora.Rainbow.csproj
+++ b/src/Viasfora.Rainbow/Viasfora.Rainbow.csproj
@@ -103,7 +103,7 @@
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Sdk">
-      <Version>17.6.36389</Version>
+      <Version>17.10.40171</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Viasfora.Xml/Viasfora.Xml.csproj
+++ b/src/Viasfora.Xml/Viasfora.Xml.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Sdk">
-      <Version>17.6.36389</Version>
+      <Version>17.10.40171</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Viasfora/Viasfora.csproj
+++ b/src/Viasfora/Viasfora.csproj
@@ -264,10 +264,12 @@
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Sdk">
-      <Version>17.6.36389</Version>
+      <Version>17.10.40171</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.3.2094</Version>
+      <Version>17.10.2185</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Viasfora/source.extension.vsixmanifest
+++ b/src/Viasfora/source.extension.vsixmanifest
@@ -34,6 +34,27 @@
         <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Premium">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
+        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.IntegratedShell">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.Pro">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.VSWinExpress">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.VWDExpress">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.VSWinDesktopExpress">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7,)" />

--- a/tests/Viasfora.Tests/Viasfora.Tests.csproj
+++ b/tests/Viasfora.Tests/Viasfora.Tests.csproj
@@ -114,22 +114,22 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
-      <Version>7.0.0</Version>
+      <Version>8.0.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Sdk">
-      <Version>17.6.36389</Version>
+      <Version>17.10.40171</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop">
-      <Version>3.6.2115</Version>
+      <Version>3.10.2154</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.4.2</Version>
+      <Version>2.9.0</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.4.5</Version>
+      <Version>2.8.2</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Enable ARM64 support so that new Copilot+ PC's can have rainbow lines goodness.