### PR TITLE
Remove unused DTE

### DIFF
--- a/src/Viasfora/Telemetry.cs
+++ b/src/Viasfora/Telemetry.cs
@@ -4,7 +4,7 @@ namespace Winterdom.Viasfora {
   public class Telemetry {
     public bool Enabled { get; private set; }
 
-    public Telemetry(bool enabled, EnvDTE80.DTE2 dte = null) {
+    public Telemetry(bool enabled) {
     }
 
     public void WriteEvent(String eventName) {

--- a/src/Viasfora/TelemetryService.cs
+++ b/src/Viasfora/TelemetryService.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
-using System;
+﻿using System;
 using System.ComponentModel.Composition;
 using Winterdom.Viasfora.Contracts;
 using Winterdom.Viasfora.Settings;
@@ -13,12 +11,11 @@ namespace Winterdom.Viasfora {
     public bool Enabled  => this.telemetry.Enabled;
 
     [ImportingConstructor]
-    public TelemetryService(SVsServiceProvider serviceProvider, ITypedSettingsStore settings) {
+    public TelemetryService(ITypedSettingsStore settings) {
       // We can't ask for IVsfSettings here because we'd create a circular
       // dependency chain, which would cause MEF to fail.
       bool telemetryEnabled = false;//settings.GetBoolean(nameof(IVsfSettings.TelemetryEnabled), true);
-      var dte = (EnvDTE80.DTE2)serviceProvider.GetService(typeof(SDTE));
-      this.telemetry = new Telemetry(telemetryEnabled, dte);
+      this.telemetry = new Telemetry(telemetryEnabled);
     }
 
     public void WriteEvent(string eventName) {


### PR DESCRIPTION
Viasfora extension may hang in Visual Studio 2026 which loads extensions on the background thread.
It seems that DTE is not used, so I've removed it.

More context: 
- https://devblogs.microsoft.com/visualstudio/performance-improvements-to-mef-based-editor-productivity-extensions/
- https://github.com/microsoft/VSSDK-Analyzers/blob/f0823e48d7a43cc84dc0eb3ce622cc149451854b/doc/VSSDK008.md
  - I recommend adding these analyzers. This would have been flagged by VSSDK008 