### PR TITLE
Fix ItalicsFormatter and BoldAsItalicsFormatter cascading recursion

### DIFF
--- a/src/Viasfora.Core/Text/BoldAsItalics.cs
+++ b/src/Viasfora.Core/Text/BoldAsItalics.cs
@@ -66,7 +66,15 @@ namespace Winterdom.Viasfora.Text {
         }
       } finally {
         this.formatMap.EndBatchUpdate();
-        this.working = false;
+        // If we change the formats, the corresponding
+        // format map update event could fire just after we leave
+        // this block, causing cascading calls.
+        // To avoid this, delay resetting the working flag
+        // until after some small time has passed.
+        System.Threading.Tasks.Task.Delay(500).ContinueWith(
+          (parentTask) => this.working = false,
+          System.Threading.Tasks.TaskScheduler.Default
+        );
       }
     }
     private void MakeItalicsIfApplies(IClassificationType classifierType) {

--- a/src/Viasfora.Core/Text/KeywordTaggerProvider.cs
+++ b/src/Viasfora.Core/Text/KeywordTaggerProvider.cs
@@ -128,7 +128,7 @@ namespace Winterdom.Viasfora.Text {
     private void SetItalics(IClassificationType classifierType, bool enable) {
       var tp = this.formatMap.GetTextProperties(classifierType);
 
-      if ( !tp.Italic ) {
+      if ( tp.Italic != enable ) {
         tp = tp.SetItalic(enable);
         this.formatMap.SetTextProperties(classifierType, tp);
       }

--- a/tests/Viasfora.Tests/Text/BoldAsItalicsFormatterTests.cs
+++ b/tests/Viasfora.Tests/Text/BoldAsItalicsFormatterTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Windows;
+using System.Windows.Media;
+using Microsoft.VisualStudio.Text.Formatting;
+using Winterdom.Viasfora.Text;
+using Xunit;
+
+namespace Viasfora.Tests.Text {
+  public class BoldAsItalicsFormatterTests {
+
+    private static BoldAsItalicsFormatter CreateFormatter(
+      FakeClassificationFormatMap formatMap,
+      FakeVsfSettings settings
+    ) {
+      var formatter = (BoldAsItalicsFormatter)FormatterServices.GetUninitializedObject(typeof(BoldAsItalicsFormatter));
+      var type = typeof(BoldAsItalicsFormatter);
+      type.GetField("formatMap", BindingFlags.NonPublic | BindingFlags.Instance)
+        .SetValue(formatter, formatMap);
+      type.GetField("settings", BindingFlags.NonPublic | BindingFlags.Instance)
+        .SetValue(formatter, settings);
+      type.GetField("working", BindingFlags.NonPublic | BindingFlags.Instance)
+        .SetValue(formatter, false);
+      return formatter;
+    }
+
+    private static bool GetWorkingFlag(BoldAsItalicsFormatter formatter) {
+      return (bool)typeof(BoldAsItalicsFormatter)
+        .GetField("working", BindingFlags.NonPublic | BindingFlags.Instance)
+        .GetValue(formatter);
+    }
+
+    private static void InvokeMakeBoldItalics(BoldAsItalicsFormatter formatter) {
+      typeof(BoldAsItalicsFormatter)
+        .GetMethod("MakeBoldItalics", BindingFlags.NonPublic | BindingFlags.Instance)
+        .Invoke(formatter, null);
+    }
+
+    [Fact]
+    public void MakeBoldItalics_WhenEnabled_WorkingFlagShouldRemainTrueAfterReturn() {
+      // The working flag must NOT be reset immediately; it should use
+      // a delayed reset (Task.Delay) to prevent re-entrant cascading.
+      var formatMap = new FakeClassificationFormatMap();
+      var settings = new FakeVsfSettings { BoldAsItalicsEnabled = true };
+      var formatter = CreateFormatter(formatMap, settings);
+
+      InvokeMakeBoldItalics(formatter);
+
+      Assert.True(GetWorkingFlag(formatter));
+    }
+
+    [Fact]
+    public void MakeBoldItalics_WhenEnabled_SecondCallShouldBeBlockedByWorkingFlag() {
+      // After the first call, a second immediate call should be blocked
+      // because the working flag hasn't been reset yet.
+      var formatMap = new FakeClassificationFormatMap();
+      var settings = new FakeVsfSettings { BoldAsItalicsEnabled = true };
+      var classifType = new FakeClassificationType("keyword");
+      var boldProps = TextFormattingRunProperties.CreateTextFormattingRunProperties(
+        new Typeface(new FontFamily("Consolas"), FontStyles.Normal, FontWeights.Bold, FontStretches.Normal),
+        12.0, Colors.Black).SetBold(true);
+      formatMap.AddEntry(classifType, boldProps);
+
+      var formatter = CreateFormatter(formatMap, settings);
+
+      // First call processes the bold→italic conversion
+      InvokeMakeBoldItalics(formatter);
+      int callsAfterFirst = formatMap.SetTextPropertiesCallCount;
+
+      // Reset the entry back to bold to ensure the second call WOULD
+      // do work if it weren't blocked
+      formatMap.AddEntry(classifType, boldProps);
+      formatMap.SetTextPropertiesCallCount = 0;
+
+      // Second call should be blocked by the working flag
+      InvokeMakeBoldItalics(formatter);
+
+      Assert.Equal(0, formatMap.SetTextPropertiesCallCount);
+    }
+
+    [Fact]
+    public void MakeBoldItalics_WhenDisabled_ShouldNotProcess() {
+      var formatMap = new FakeClassificationFormatMap();
+      var settings = new FakeVsfSettings { BoldAsItalicsEnabled = false };
+      var formatter = CreateFormatter(formatMap, settings);
+
+      InvokeMakeBoldItalics(formatter);
+
+      Assert.Equal(0, formatMap.SetTextPropertiesCallCount);
+      Assert.False(GetWorkingFlag(formatter));
+    }
+  }
+}

--- a/tests/Viasfora.Tests/Text/ItalicsFormatterTests.cs
+++ b/tests/Viasfora.Tests/Text/ItalicsFormatterTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
+using Microsoft.VisualStudio.Text.Formatting;
+using Winterdom.Viasfora.Text;
+using Xunit;
+
+namespace Viasfora.Tests.Text {
+  public class ItalicsFormatterTests {
+
+    private static ItalicsFormatter CreateFormatter(
+      FakeClassificationFormatMap formatMap,
+      FakeVsfSettings settings,
+      List<string> classificationTypes
+    ) {
+      // Bypass the constructor (which needs ITextView) by creating
+      // an uninitialized instance and setting fields via reflection.
+      var formatter = (ItalicsFormatter)FormatterServices.GetUninitializedObject(typeof(ItalicsFormatter));
+      var type = typeof(ItalicsFormatter);
+      type.GetField("formatMap", BindingFlags.NonPublic | BindingFlags.Instance)
+        .SetValue(formatter, formatMap);
+      type.GetField("settings", BindingFlags.NonPublic | BindingFlags.Instance)
+        .SetValue(formatter, settings);
+      type.GetField("classificationTypes", BindingFlags.NonPublic | BindingFlags.Instance)
+        .SetValue(formatter, classificationTypes);
+      type.GetField("working", BindingFlags.NonPublic | BindingFlags.Instance)
+        .SetValue(formatter, false);
+      return formatter;
+    }
+
+    [Fact]
+    public void FixIt_WhenItalicsDisabled_AndTextNotItalic_ShouldNotCallSetTextProperties() {
+      // Text is already non-italic and setting is disabled → pure no-op
+      var formatMap = new FakeClassificationFormatMap();
+      var settings = new FakeVsfSettings { FlowControlUseItalics = false };
+      var classifType = new FakeClassificationType("Viasfora Flow Control Keyword");
+      var nonItalicProps = TextFormattingRunProperties.CreateTextFormattingRunProperties();
+      formatMap.AddEntry(classifType, nonItalicProps);
+
+      var formatter = CreateFormatter(formatMap, settings,
+        new List<string> { "Viasfora Flow Control Keyword" });
+
+      formatter.FixIt();
+
+      Assert.Equal(0, formatMap.SetTextPropertiesCallCount);
+    }
+
+    [Fact]
+    public void FixIt_WhenItalicsDisabled_AndTextIsItalic_ShouldRemoveItalics() {
+      // Text IS italic but setting says don't use italics → should remove
+      var formatMap = new FakeClassificationFormatMap();
+      var settings = new FakeVsfSettings { FlowControlUseItalics = false };
+      var classifType = new FakeClassificationType("Viasfora Flow Control Keyword");
+      var italicProps = TextFormattingRunProperties.CreateTextFormattingRunProperties()
+        .SetItalic(true);
+      formatMap.AddEntry(classifType, italicProps);
+
+      var formatter = CreateFormatter(formatMap, settings,
+        new List<string> { "Viasfora Flow Control Keyword" });
+
+      formatter.FixIt();
+
+      Assert.Equal(1, formatMap.SetTextPropertiesCallCount);
+      Assert.False(formatMap.LastSetProperties.Italic);
+    }
+
+    [Fact]
+    public void FixIt_WhenItalicsEnabled_AndTextNotItalic_ShouldAddItalics() {
+      // Text is not italic, setting says use italics → should add
+      var formatMap = new FakeClassificationFormatMap();
+      var settings = new FakeVsfSettings { FlowControlUseItalics = true };
+      var classifType = new FakeClassificationType("Viasfora Flow Control Keyword");
+      var nonItalicProps = TextFormattingRunProperties.CreateTextFormattingRunProperties();
+      formatMap.AddEntry(classifType, nonItalicProps);
+
+      var formatter = CreateFormatter(formatMap, settings,
+        new List<string> { "Viasfora Flow Control Keyword" });
+
+      formatter.FixIt();
+
+      Assert.Equal(1, formatMap.SetTextPropertiesCallCount);
+      Assert.True(formatMap.LastSetProperties.Italic);
+    }
+
+    [Fact]
+    public void FixIt_WhenItalicsEnabled_AndTextAlreadyItalic_ShouldNotCallSetTextProperties() {
+      // Text is already italic and setting is enabled → no change needed
+      var formatMap = new FakeClassificationFormatMap();
+      var settings = new FakeVsfSettings { FlowControlUseItalics = true };
+      var classifType = new FakeClassificationType("Viasfora Flow Control Keyword");
+      var italicProps = TextFormattingRunProperties.CreateTextFormattingRunProperties()
+        .SetItalic(true);
+      formatMap.AddEntry(classifType, italicProps);
+
+      var formatter = CreateFormatter(formatMap, settings,
+        new List<string> { "Viasfora Flow Control Keyword" });
+
+      formatter.FixIt();
+
+      Assert.Equal(0, formatMap.SetTextPropertiesCallCount);
+    }
+
+    [Fact]
+    public void FixIt_NonMatchingClassificationType_ShouldNotCallSetTextProperties() {
+      // Classification type doesn't match what formatter tracks → ignore
+      var formatMap = new FakeClassificationFormatMap();
+      var settings = new FakeVsfSettings { FlowControlUseItalics = true };
+      var classifType = new FakeClassificationType("Some Other Type");
+      var nonItalicProps = TextFormattingRunProperties.CreateTextFormattingRunProperties();
+      formatMap.AddEntry(classifType, nonItalicProps);
+
+      var formatter = CreateFormatter(formatMap, settings,
+        new List<string> { "Viasfora Flow Control Keyword" });
+
+      formatter.FixIt();
+
+      Assert.Equal(0, formatMap.SetTextPropertiesCallCount);
+    }
+  }
+}

--- a/tests/Viasfora.Tests/Text/TestDoubles.cs
+++ b/tests/Viasfora.Tests/Text/TestDoubles.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Microsoft.VisualStudio.Text.Classification;
+using Microsoft.VisualStudio.Text.Formatting;
+using Winterdom.Viasfora;
+using Winterdom.Viasfora.Outlining;
+using Winterdom.Viasfora.Text;
+
+namespace Viasfora.Tests.Text {
+
+  internal class FakeClassificationType : IClassificationType {
+    public string Classification { get; }
+    public IEnumerable<IClassificationType> BaseTypes => Array.Empty<IClassificationType>();
+
+    public FakeClassificationType(string name) {
+      Classification = name;
+    }
+
+    public bool IsOfType(string type) {
+      return String.Equals(Classification, type, StringComparison.Ordinal);
+    }
+  }
+
+  internal class FakeClassificationFormatMap : IClassificationFormatMap {
+    private readonly Dictionary<string, TextFormattingRunProperties> properties
+      = new Dictionary<string, TextFormattingRunProperties>();
+    private readonly List<IClassificationType> priorityOrder
+      = new List<IClassificationType>();
+    private bool inBatchUpdate;
+
+    public int SetTextPropertiesCallCount { get; set; }
+    public TextFormattingRunProperties LastSetProperties { get; private set; }
+
+    public event EventHandler<EventArgs> ClassificationFormatMappingChanged;
+
+    public bool IsInBatchUpdate => inBatchUpdate;
+
+    public ReadOnlyCollection<IClassificationType> CurrentPriorityOrder =>
+      new ReadOnlyCollection<IClassificationType>(priorityOrder);
+
+    public TextFormattingRunProperties DefaultTextProperties { get; set; }
+      = TextFormattingRunProperties.CreateTextFormattingRunProperties();
+
+    public void AddEntry(IClassificationType type, TextFormattingRunProperties props) {
+      properties[type.Classification] = props;
+      if ( !priorityOrder.Contains(type) ) {
+        priorityOrder.Add(type);
+      }
+    }
+
+    public TextFormattingRunProperties GetTextProperties(IClassificationType classificationType) {
+      return properties.TryGetValue(classificationType.Classification, out var props)
+        ? props
+        : TextFormattingRunProperties.CreateTextFormattingRunProperties();
+    }
+
+    public TextFormattingRunProperties GetExplicitTextProperties(IClassificationType classificationType) {
+      return GetTextProperties(classificationType);
+    }
+
+    public void SetTextProperties(IClassificationType classificationType, TextFormattingRunProperties props) {
+      properties[classificationType.Classification] = props;
+      SetTextPropertiesCallCount++;
+      LastSetProperties = props;
+    }
+
+    public void SetExplicitTextProperties(IClassificationType classificationType, TextFormattingRunProperties props) {
+      SetTextProperties(classificationType, props);
+    }
+
+    public void AddExplicitTextProperties(IClassificationType classificationType, TextFormattingRunProperties props) { }
+    public void AddExplicitTextProperties(IClassificationType classificationType, TextFormattingRunProperties props, IClassificationType after) { }
+
+    public void SwapPriorities(IClassificationType first, IClassificationType second) { }
+
+    public string GetEditorFormatMapKey(IClassificationType classificationType) {
+      return classificationType?.Classification ?? string.Empty;
+    }
+
+    public void BeginBatchUpdate() { inBatchUpdate = true; }
+    public void EndBatchUpdate() { inBatchUpdate = false; }
+
+    public void RaiseChanged() {
+      ClassificationFormatMappingChanged?.Invoke(this, EventArgs.Empty);
+    }
+  }
+
+  internal class FakeVsfSettings : IVsfSettings {
+    public event EventHandler SettingsChanged;
+    public bool FlowControlUseItalics { get; set; }
+    public bool BoldAsItalicsEnabled { get; set; }
+    public bool KeywordClassifierEnabled { get; set; }
+    public bool FlowControlKeywordsEnabled { get; set; }
+    public bool VisibilityKeywordsEnabled { get; set; }
+    public bool QueryKeywordsEnabled { get; set; }
+    public bool EscapeSequencesEnabled { get; set; }
+    public bool CurrentLineHighlightEnabled { get; set; }
+    public bool CurrentColumnHighlightEnabled { get; set; }
+    public ColumnStyle CurrentColumnHighlightStyle { get; set; }
+    public double HighlightLineWidth { get; set; }
+    public bool PresentationModeEnabled { get; set; }
+    public int PresentationModeDefaultZoom { get; set; }
+    public int PresentationModeEnabledZoom { get; set; }
+    public bool PresentationModeIncludeEnvFonts { get; set; }
+    public bool ModelinesEnabled { get; set; }
+    public int ModelinesNumLines { get; set; }
+    public bool DeveloperMarginEnabled { get; set; }
+    public AutoExpandMode AutoExpandRegions { get; set; }
+    public string TextObfuscationRegexes { get; set; }
+    public bool TelemetryEnabled { get; set; }
+    public void Load() { }
+    public void Save() { }
+    public void RaiseSettingsChanged() {
+      SettingsChanged?.Invoke(this, EventArgs.Empty);
+    }
+  }
+}

--- a/tests/Viasfora.Tests/Viasfora.Tests.csproj
+++ b/tests/Viasfora.Tests/Viasfora.Tests.csproj
@@ -88,6 +88,9 @@
     <Compile Include="VsfEditorHost.cs" />
     <Compile Include="VsfEditorHostFactory.cs" />
     <Compile Include="VsfVsTestBase.cs" />
+    <Compile Include="Text\TestDoubles.cs" />
+    <Compile Include="Text\ItalicsFormatterTests.cs" />
+    <Compile Include="Text\BoldAsItalicsFormatterTests.cs" />
     <Compile Include="VsSolutionTests.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary

Fixes two bugs in the format map update handlers that cause infinite re-entrant calls when multiple editor tabs are open, leading to UI thread hangs.

### Bug 1: `ItalicsFormatter.SetItalics` condition (root cause)

**Before:** `if (!tp.Italic)` — enters the block whenever text is not italic, regardless of the `enable` parameter.

When `FlowControlUseItalics = false` and text is already non-italic, this calls `tp.SetItalic(false)` which creates a **new** `TextFormattingRunProperties` object reference. `SetTextProperties` stores this new reference and marks the batch dirty, causing `EndBatchUpdate` to fire `ClassificationFormatMappingChanged` to every `ViewSpecificFormatMap` (one per open tab). Each of those fires to subscribers including `WpfLineNumberMargin.UpdateLineNumbers()` which performs expensive native text shaping. With N tabs, this creates O(N²) expensive operations per cascade level.

Additionally, the old condition could never **remove** italics — when the setting changes from true→false, italic text would be skipped by `!tp.Italic`.

**After:** `if (tp.Italic != enable)` — only calls `SetTextProperties` when the italic state actually needs to change.

### Bug 2: `BoldAsItalicsFormatter` immediate working flag reset

**Before:** `this.working = false` immediately after `EndBatchUpdate()`.

The `EndBatchUpdate()` call fires `ClassificationFormatMappingChanged`, which synchronously calls `OnMappingChanged` → `MakeBoldItalics()`. Since `working` was already reset to `false`, the re-entrant call proceeds, creating the same cascading pattern.

**After:** Uses the same `Task.Delay(500).ContinueWith()` pattern already present in `ItalicsFormatter.FixItalics()` (added in the fix for #252).

### Tests

Added 8 xUnit tests covering both formatters using manual test doubles (no new dependencies):
- **ItalicsFormatter**: 5 tests covering all combinations of italic state × enable setting, plus non-matching classification types
- **BoldAsItalicsFormatter**: 3 tests verifying the delayed working flag, re-entrancy protection, and disabled-setting behavior

All 247 tests pass (239 existing + 8 new).

Relates to #252