### PR TITLE
Fixed issues with rainbow braces color settings being reset every time VS 2026 starts up.

### DIFF
--- a/src/Viasfora.Core/PkgSource.cs
+++ b/src/Viasfora.Core/PkgSource.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.VisualStudio.Shell;
 using Winterdom.Viasfora.Compatibility;
 using Winterdom.Viasfora.Contracts;
 
@@ -8,6 +9,9 @@ namespace Winterdom.Viasfora {
     private static Lazy<ILogger> logger = new Lazy<ILogger>(GetLogger);
 
     public static void LogError(String message, Exception ex) {
+      if ( !ThreadHelper.CheckAccess() ) {
+        return;
+      }
       if ( logger.Value != null ) {
         logger.Value.LogError(message, ex);
       }

--- a/src/Viasfora/Options/ClassificationColors.cs
+++ b/src/Viasfora/Options/ClassificationColors.cs
@@ -68,7 +68,9 @@ namespace Winterdom.Viasfora.Options {
       if ( this.HasChanged() ) {
         ColorableItemInfo[] colors = new ColorableItemInfo[1];
         var hr = colorStorage.Storage.GetItem(this.classificationName, colors);
-        ErrorHandler.ThrowOnFailure(hr);
+        if ( ErrorHandler.Failed(hr) ) {
+          colors[0] = new ColorableItemInfo();
+        }
 
         AssignForSave(colorStorage, colors);
 

--- a/src/Viasfora/Options/ClassificationList.cs
+++ b/src/Viasfora/Options/ClassificationList.cs
@@ -50,8 +50,7 @@ namespace Winterdom.Viasfora.Options {
     public void Save() {
       ThreadHelper.ThrowIfNotOnUIThread();
       Guid category = new Guid(FontsAndColorsCategories.TextEditorCategory);
-      uint flags = (uint)(__FCSTORAGEFLAGS.FCSF_LOADDEFAULTS
-                        | __FCSTORAGEFLAGS.FCSF_PROPAGATECHANGES);
+      uint flags = (uint)(__FCSTORAGEFLAGS.FCSF_PROPAGATECHANGES);
       var hr = this.storage.Storage.OpenCategory(ref category, flags);
       ErrorHandler.ThrowOnFailure(hr);
 

--- a/src/Viasfora/Options/GeneralOptionsPage.cs
+++ b/src/Viasfora/Options/GeneralOptionsPage.cs
@@ -12,6 +12,7 @@ namespace Winterdom.Viasfora.Options {
 
     public override void SaveSettingsToStorage() {
       ThreadHelper.ThrowIfNotOnUIThread();
+      if ( this.colors == null ) return;
       var settings = SettingsContext.GetSettings();
 
       settings.CurrentLineHighlightEnabled = CurrentLineHighlightEnabled;

--- a/src/Viasfora/Options/RainbowOptionsPage.cs
+++ b/src/Viasfora/Options/RainbowOptionsPage.cs
@@ -12,6 +12,7 @@ namespace Winterdom.Viasfora.Options {
 
     public override void SaveSettingsToStorage() {
       ThreadHelper.ThrowIfNotOnUIThread();
+      if ( this.colors == null ) return;
       var rainbowSettings = SettingsContext.GetService<IRainbowSettings>();
 
       rainbowSettings.RainbowDepth = RainbowDepth;

--- a/src/Viasfora/Options/XmlOptionsPage.cs
+++ b/src/Viasfora/Options/XmlOptionsPage.cs
@@ -12,6 +12,7 @@ namespace Winterdom.Viasfora.Options {
 
     public override void SaveSettingsToStorage() {
       ThreadHelper.ThrowIfNotOnUIThread();
+      if ( this.colors == null ) return;
       var settings = SettingsContext.GetService<IXmlSettings>();
 
       settings.XmlnsPrefixEnabled = XmlnsPrefixHighlightEnabled;


### PR DESCRIPTION
This PR is addressing issue #360 and replaces PR #361 which did not have a clean history.

Full disclaimer, this fix was AI generated, but the logic seems sound (posted below for you to review), it fixed the issue, and the changes are fairly minimal, so hopefully it's a fairly clean change. 

// AI Explanation of Fixes
1. ClassificationList.Save() — FCSF_LOADDEFAULTS in write mode (ClassificationList.cs)
The main bug. The Save() method opened the Text Editor font/color category with FCSF_LOADDEFAULTS | FCSF_PROPAGATECHANGES. Per the VS SDK docs, FCSF_LOADDEFAULTS means "settings not yet in the registry are loaded directly from the VSPackage defaults". Using this flag in write mode (no FCSF_READONLY) causes VS to load all rainbow classification items from the EditorFormatDefinition constructors (i.e., the hardcoded factory defaults). In VS 2026, when CloseCategory is then called with FCSF_PROPAGATECHANGES, VS broadcasts these default-loaded values to the editor, overwriting whatever the user had saved.
Fix: Changed the save flags to FCSF_PROPAGATECHANGES only — the correct VS SDK pattern for writing user color changes.

2. ClassificationColors.Save() — GetItem failure not handled (ClassificationColors.cs)
Consequence of fix no. 1. Without FCSF_LOADDEFAULTS, GetItem returns a failure code for any classification item that has never been explicitly customized by the user (not yet in the registry). The original code threw on that failure code. Now it gracefully falls back to an empty ColorableItemInfo, allowing AssignForSave(ColorStorage, ColorableItemInfo[]) to populate only the changed fields before SetItem creates the new registry entry.

3. SaveSettingsToStorage() null guard — all three option pages (RainbowOptionsPage.cs, GeneralOptionsPage.cs, XmlOptionsPage.cs)
Defensive fix. All three pages initialize colors only inside LoadSettingsFromStorage(). If VS 2026 calls SaveSettingsToStorage() at package initialization before the page has been opened (which newer VS versions do), colors is null and the page's properties are all at their C# defaults (false, 0, etc.). This would silently write values like RainbowTagsEnabled = false and RainbowDepth = 0 to Viasfora.Xml.csproj, corrupting functional settings. The early return guard prevents this.

// Additional Fix For Error Thrown During Testing in SComponentModel.cs (line ThreadHelper.ThrowIfNotOnUIThread();) called from PkgSource.cs 

What caused the exception
The SComponentModel exception was a real, pre-existing bug that VS 2026's more aggressive background threading exposed. The chain was:
1.	Some VS COM operation (inside TextEditor.cs or VsSolution.cs) returned a non-S_OK HRESULT on a background thread
2.	CheckError() called PkgSource.LogError() to log it
3.	LogError() accessed Value — this was the first access, so Lazy<T> ran the factory GetLogger() on that background thread
4.	GetLogger() called new SComponentModel(), which has ThreadHelper.ThrowIfNotOnUIThread() — and that threw, because SComponentModel has no thread guard of its own
It happened only once in the debugger because the debugger breaks on thrown exceptions. But the damage was actually worse than it appeared — Lazy<T> with default threading caches thrown exceptions, meaning all subsequent calls to Value would also re-throw, permanently breaking error logging for that VS session (silently in non-debug mode).
Why it wasn't caused by our changes
Our changes only touched ClassificationList.cs, ClassificationColors.cs, and the three option pages — none of which are in the LogError(String, Exception) → GetLogger() → SComponentModel call chain.
Why the fix works
Guarding at the LogError() level (before Value is ever touched) is the correct approach because:
•	Lazy<T> is never initialized from a background thread — the factory GetLogger() can only run when LogError() is called on the UI thread, so SComponentModel is always safe
•	The cached logger is never null — unlike guarding inside GetLogger() (which would cache null permanently if first called from a background thread, disabling logging forever)
•	Background thread errors are silently skipped — acceptable since those error paths are diagnostic-only and logging them on the UI thread would require a thread-switch that could deadlock